### PR TITLE
Fix setDefaultValueCallback

### DIFF
--- a/src/Entity/Redirect.php
+++ b/src/Entity/Redirect.php
@@ -471,7 +471,7 @@ class Redirect extends ContentEntityBase {
     $fields['uid'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('User ID'))
       ->setDescription(t('The user ID of the node author.'))
-      ->setDefaultValueCallback(array('Drupal\redirect\Entity\Redirect', 'getCurrentUserId'))
+      ->setDefaultValueCallback('\Drupal\redirect\Entity\Redirect::getCurrentUserId')
       ->setSettings(array(
         'target_type' => 'user',
       ));

--- a/src/Entity/Redirect.php
+++ b/src/Entity/Redirect.php
@@ -208,7 +208,7 @@ class Redirect extends ContentEntityBase {
     try {
       $parsed_url = UrlHelper::parse($url);
 
-      $url = Url::createFromPath($parsed_url['path']);
+      $url = Url::fromUri($parsed_url['path']);
       if (!empty($parsed_url['query'])) {
         $url->setOption('query', $parsed_url['query']);
       }
@@ -300,7 +300,7 @@ class Redirect extends ContentEntityBase {
     // Make sure we have the system path.
     $parsed_url['path'] = $alias_manager->getPathByAlias($parsed_url['path']);
 
-    $url = Url::createFromPath($parsed_url['path']);
+    $url = Url::fromUri($parsed_url['path']);
     if (!empty($parsed_url['query'])) {
       $url->setOption('query', $parsed_url['query']);
     }


### PR DESCRIPTION
Travis build (https://travis-ci.org/md-systems/redirect/jobs/36773521) failing with below trace:

```
Enabled modules: redirect, link, field, system, user.
```

Exception Uncaught e BaseFieldDefiniti  415 Drupal\Core\Field\BaseFieldDefiniti
    InvalidArgumentException: Default value callback must be a string, like
    &quot;function_name&quot; or &quot;ClassName::methodName&quot; in
    Drupal\Core\Field\BaseFieldDefinition-&gt;setDefaultValueCallback() (line
    415 of
    /home/travis/build/md-systems/drupal/core/lib/Drupal/Core/Field/BaseFieldDefinition.php).
    Drupal\Core\Field\BaseFieldDefinition->setDefaultValueCallback(Array)
    Drupal\redirect\Entity\Redirect::baseFieldDefinitions(Object)
    Drupal\Core\Entity\EntityManager->buildBaseFieldDefinitions('redirect')
    Drupal\Core\Entity\EntityManager->getBaseFieldDefinitions('redirect')
    Drupal\Core\Entity\EntityManager->getFieldStorageDefinitions('redirect')
    Drupal\Core\Entity\Sql\SqlContentEntityStorageSchema->__construct(Object,
    Object, Object, Object)
    Drupal\Core\Entity\Sql\SqlContentEntityStorage->getStorageSchema()
    Drupal\Core\Entity\Sql\SqlContentEntityStorage->onEntityTypeCreate(Object)
    Drupal\Core\Entity\EntityManager->onEntityTypeCreate(Object)
    Drupal\simpletest\KernelTestBase->installEntitySchema('redirect')
    Drupal\redirect\Tests\RedirectAPITest->setUp()
    Drupal\simpletest\TestBase->run()
    simpletest_script_run_one_test('1', 'Drupal\redirect\Tests\RedirectAPITest')

This is an impact of https://www.drupal.org/node/2346911
