### PR TITLE
Gets additional tests passing.

### DIFF
--- a/redirect.routing.yml
+++ b/redirect.routing.yml
@@ -14,7 +14,7 @@ redirect.add:
   requirements:
     _entity_create_access: 'redirect'
 
-redirect.edit:
+entity.redirect.edit_form:
   path: '/admin/config/search/redirect/edit/{redirect}'
   defaults:
     _entity_form: 'redirect.edit'
@@ -22,7 +22,7 @@ redirect.edit:
   requirements:
     _entity_access: 'redirect.update'
 
-redirect.delete:
+entity.redirect.delete_form:
   path: '/admin/config/search/redirect/delete/{redirect}'
   defaults:
     _entity_form: 'redirect.delete'

--- a/src/Entity/Redirect.php
+++ b/src/Entity/Redirect.php
@@ -41,8 +41,8 @@ use Drupal\link\LinkItemInterface;
  *     "bundle" = "type"
  *   },
  *   links = {
- *     "delete-form" = "redirect.delete",
- *     "edit-form" = "redirect.edit",
+ *     "delete-form" = "/admin/config/search/redirect/delete/{redirect}",
+ *     "edit-form" = "/admin/config/search/redirect/edit/{redirect}'",
  *   }
  * )
  */

--- a/src/Entity/Redirect.php
+++ b/src/Entity/Redirect.php
@@ -296,11 +296,11 @@ class Redirect extends ContentEntityBase {
     if (!$url) {
       $url = Url::fromUri('base://' . $parsed_url['path']);
     }
-    if (!empty($parsed_url['query'])) {
-      $url->setOption('query', $parsed_url['query']);
+    if (!empty($options['query'])) {
+      $url->setOption('query', $options['query']);
     }
-    if (!empty($parsed_url['fragment'])) {
-      $url->setOption('fragment', $parsed_url['fragment']);
+    if (!empty($options['fragment'])) {
+      $url->setOption('fragment', $options['fragment']);
     }
 
     $value = $url->toArray();

--- a/src/Entity/Redirect.php
+++ b/src/Entity/Redirect.php
@@ -283,10 +283,10 @@ class Redirect extends ContentEntityBase {
   }
 
   /**
-   * Sets the source URL data.
+   * Sets the redirect destination URL data.
    *
    * @param string $url
-   *   The base url of the source.
+   *   The base url of the redirect destination.
    * @param array $options
    *   The source url options.
    */

--- a/src/Tests/RedirectRequestSubscriberTest.php
+++ b/src/Tests/RedirectRequestSubscriberTest.php
@@ -108,7 +108,7 @@ class RedirectRequestSubscriberTest extends UnitTestCase {
       ->getMock();
     $url_generator->expects($this->once())
       ->method('generateFromPath')
-      ->with($route_url, array('external' => TRUE, 'query' => $final_query))
+      ->with($route_url, array('absolute' => TRUE, 'query' => $final_query))
       ->will($this->returnValue('dummy_value'));
     $url_generator->expects($this->never())
       ->method('generateFromRoute');
@@ -128,7 +128,7 @@ class RedirectRequestSubscriberTest extends UnitTestCase {
       ->getMock();
     $url_generator->expects($this->once())
       ->method('generateFromPath')
-      ->with($route_url, array('external' => TRUE, 'query' => $final_query))
+      ->with($route_url, array('absolute' => TRUE, 'query' => $final_query))
       ->will($this->returnValue('dummy_value'));
     $url_generator->expects($this->never())
       ->method('generateFromRoute');


### PR DESCRIPTION
Not all tests are passing yet, but this gets rid of fatal errors and exceptions.

I think the remaining failures are due to the internal path being deprecated--this module may need to store route information when available.
