### PR TITLE
Incompatible with the language and content_translation modules.

### DIFF
--- a/config/optional/language.content_settings.redirect.redirect.yml
+++ b/config/optional/language.content_settings.redirect.redirect.yml
@@ -1,0 +1,7 @@
+status: true
+dependencies: {  }
+id: redirect.redirect
+target_entity_type_id: redirect
+target_bundle: redirect
+default_langcode: und
+language_alterable: true

--- a/redirect.routing.yml
+++ b/redirect.routing.yml
@@ -6,6 +6,14 @@ redirect.list:
   requirements:
     _permission: 'administer redirects'
 
+entity.redirect.canonical:
+  path: '/admin/config/search/redirect/edit/{redirect}'
+  defaults:
+    _entity_form: 'redirect.edit'
+    _title: 'Edit URL redirect'
+  requirements:
+    _entity_access: 'redirect.update'
+
 redirect.add:
   path: '/admin/config/search/redirect/add'
   defaults:

--- a/src/Entity/Redirect.php
+++ b/src/Entity/Redirect.php
@@ -306,9 +306,12 @@ class Redirect extends ContentEntityBase {
       ->setDisplayConfigurable('form', TRUE);
 
     $fields['language'] = BaseFieldDefinition::create('language')
-      ->setLabel(t('Language code'))
-      ->setDescription(t('The node language code.'))
-      ->setDefaultValue(LanguageInterface::LANGCODE_NOT_SPECIFIED);
+      ->setLabel(t('Language'))
+      ->setDescription(t('The redirect language.'))
+      ->setDisplayOptions('form', array(
+        'type' => 'language_select',
+        'weight' => 2,
+      ));
 
     $fields['status_code'] = BaseFieldDefinition::create('integer')
       ->setLabel(t('Status code'))

--- a/src/Entity/Redirect.php
+++ b/src/Entity/Redirect.php
@@ -42,8 +42,9 @@ use Drupal\link\LinkItemInterface;
  *     "langcode" = "language",
  *   },
  *   links = {
+ *     "canonical" = "/admin/config/search/redirect/edit/{redirect}",
  *     "delete-form" = "/admin/config/search/redirect/delete/{redirect}",
- *     "edit-form" = "/admin/config/search/redirect/edit/{redirect}'",
+ *     "edit-form" = "/admin/config/search/redirect/edit/{redirect}",
  *   }
  * )
  */

--- a/src/Form/RedirectForm.php
+++ b/src/Form/RedirectForm.php
@@ -117,7 +117,7 @@ class RedirectForm extends ContentEntityForm {
     $parsed_url = UrlHelper::parse(trim($source['path']));
     $path = isset($parsed_url['path']) ? $parsed_url['path'] : NULL;
     $query = isset($parsed_url['query']) ? $parsed_url['query'] : NULL;
-    $hash = Redirect::generateHash($path, $query, $form_state->getValue('language'));
+    $hash = Redirect::generateHash($path, $query, $form_state->getValue('language')[0]['value']);
 
     // Search for duplicate.
     $redirects = \Drupal::entityManager()

--- a/src/Form/RedirectForm.php
+++ b/src/Form/RedirectForm.php
@@ -71,22 +71,6 @@ class RedirectForm extends ContentEntityForm {
     /** @var \Drupal\redirect\Entity\Redirect $redirect */
     $redirect = $this->entity;
 
-    if (\Drupal::moduleHandler()->moduleExists('language')) {
-      $form['language'] = array(
-        '#type' => 'language_select',
-        '#title' => t('Language'),
-        '#languages' => Language::STATE_ALL,
-        '#default_value' => $this->getFormLangcode($form_state),
-        '#description' => t('A redirect set for a specific language will always be used when requesting this page in that language, and takes precedence over redirects set for <em>All languages</em>.'),
-      );
-    }
-    else {
-      $form['language'] = array(
-        '#type' => 'value',
-        '#value' => Language::LANGCODE_NOT_SPECIFIED,
-      );
-    }
-
     $default_code = $redirect->getStatusCode() ? $redirect->getStatusCode() : \Drupal::config('redirect.settings')->get('default_status_code');
 
     $form['status_code'] = array(

--- a/src/Form/RedirectForm.php
+++ b/src/Form/RedirectForm.php
@@ -76,7 +76,7 @@ class RedirectForm extends ContentEntityForm {
         '#type' => 'language_select',
         '#title' => t('Language'),
         '#languages' => Language::STATE_ALL,
-        '#default_value' => $form['language']['#value'],
+        '#default_value' => $this->getFormLangcode($form_state),
         '#description' => t('A redirect set for a specific language will always be used when requesting this page in that language, and takes precedence over redirects set for <em>All languages</em>.'),
       );
     }

--- a/src/Tests/RedirectUILanguageTest.php
+++ b/src/Tests/RedirectUILanguageTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\redirect\Tests\RedirectUILanguageTest
+ */
+
+namespace Drupal\redirect\Tests;
+
+/**
+ * UI tests for redirect module with language and content translation modules.
+ *
+ * This runs the exact same tests as RedirectUITest, but with both the language
+ * and content translation modules enabled.
+ *
+ * @group redirect
+ */
+class RedirectUILanguageTest extends RedirectUITest {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = ['redirect', 'node', 'path', 'dblog', 'views', 'taxonomy', 'language', 'content_translation'];
+
+}

--- a/src/Tests/RedirectUITest.php
+++ b/src/Tests/RedirectUITest.php
@@ -37,11 +37,9 @@ class RedirectUITest extends WebTestBase {
    protected $storage;
 
   /**
-   * Modules to enable.
-   *
-   * @var array
+   * {@inheritdoc}
    */
-  public static $modules = ['redirect', 'node', 'path', 'dblog', 'views', 'taxonomy', 'language', 'content_translation'];
+  public static $modules = ['redirect', 'node', 'path', 'dblog', 'views', 'taxonomy'];
 
   /**
    * {@inheritdoc}

--- a/src/Tests/RedirectUITest.php
+++ b/src/Tests/RedirectUITest.php
@@ -41,7 +41,7 @@ class RedirectUITest extends WebTestBase {
    *
    * @var array
    */
-  public static $modules = ['redirect', 'node', 'path', 'dblog', 'views', 'taxonomy'];
+  public static $modules = ['redirect', 'node', 'path', 'dblog', 'views', 'taxonomy', 'language', 'content_translation'];
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
When just the `language` module is enabled, this warning appears on the redirect form:

```
Notice: Undefined index: language in Drupal\redirect\Form\RedirectForm->form() (line 79 of ...)
```

When the `content_translation` module is enabled, the page becomes unusable with:

```
Drupal\Core\Entity\Exception\UndefinedLinkTemplateException: No link template "canonical" found for the "redirect" entity type in Drupal\Core\Entity\Entity->urlInfo()
```
