### PR TITLE
Fix for passthrough_redirect behavior

### DIFF
--- a/config/schema/redirect.schema.yml
+++ b/config/schema/redirect.schema.yml
@@ -11,7 +11,7 @@ redirect.settings:
       type: boolean
       label: 'Automatically create redirects when URL aliases are changed.'
     default_status_code:
-      type: string
+      type: integer
       label: 'Default redirect status'
     passthrough_querystring:
       type: boolean

--- a/redirect.services.yml
+++ b/redirect.services.yml
@@ -1,7 +1,7 @@
 services:
   redirect.repository:
     class: Drupal\redirect\RedirectRepository
-    arguments: ['@entity.manager', '@database']
+    arguments: ['@entity.manager', '@database', '@config.factory']
     tags:
       - { name: backend_overridable }
   redirect.checker:


### PR DESCRIPTION
Currently, if one sets a redirect from `/foo` to `/bar`, and then browses to `/foo?baz=1`, they get a 404, rather than being redirected to `/bar?baz=1`.
