### PR TITLE
Hashes need to be case-insensitive since source paths are.

### DIFF
--- a/redirect.install
+++ b/redirect.install
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Update hooks for the Redirect module.
+ */
+
+use Drupal\redirect\Entity\Redirect;
+
+/**
+ * Rehash redirects to account for case insensitivity.
+ */
+function redirect_update_8100 (&$sandbox) {
+  // Loop through 100 redirects at a time.
+  if (!isset($sandbox['progress'])) {
+    $sandbox['progress'] = 0;
+    $sandbox['current_rid'] = 0;
+    // Note, because MySQL can treat `foo = LOWER(foo)`, all records must be checked.
+    $sandbox['max'] = db_query('SELECT COUNT(1) FROM {redirect}')->fetchField();
+  }
+
+  $redirects = db_select('redirect', 'r')
+    ->fields('r', ['rid'])
+    ->condition('rid', $sandbox['current_rid'], '>')
+    ->range(0, 100)
+    ->orderBy('rid', 'ASC')
+    ->execute()
+    ->fetchCol();
+
+  /** @var \Drupal\redirect\RedirectRepository $repository */
+  $repository = \Drupal::service('redirect.repository');
+  $redirects = $repository->loadMultiple($redirects);
+  foreach ($redirects as $redirect) {
+    $source = $redirect->get('redirect_source')->get(0)->getValue();
+    $language = $redirect->get('language')->get(0)->getValue()['value'];
+    $query = $source['query'] ?: [];
+    $new_hash = Redirect::generateHash($source['path'], $query, $language);
+    if ($redirect->getHash() != $new_hash) {
+      // Do a direct query to speed things up.
+      db_update('redirect')
+        ->fields(['hash' => $new_hash])
+        ->condition('rid', $redirect->id())
+        ->execute();
+    }
+    $sandbox['progress']++;
+    $sandbox['current_rid'] = $redirect->id();
+  }
+  // Reset caches.
+  $sandbox['#finished'] = empty($sandbox['max']) ? 1 : ($sandbox['progress'] / $sandbox['max']);
+}

--- a/src/Entity/Redirect.php
+++ b/src/Entity/Redirect.php
@@ -65,7 +65,7 @@ class Redirect extends ContentEntityBase {
    */
   public static function generateHash($source_path, array $source_query, $language) {
     $hash = array(
-      'source' => $source_path,
+      'source' => strtolower($source_path),
       'language' => $language,
     );
 

--- a/src/Entity/Redirect.php
+++ b/src/Entity/Redirect.php
@@ -7,6 +7,7 @@
 namespace Drupal\redirect\Entity;
 
 use Drupal\Component\Utility\Crypt;
+use Drupal\Component\Utility\Unicode;
 use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Entity\ContentEntityBase;
 use Drupal\Core\Entity\EntityStorageInterface;
@@ -65,7 +66,7 @@ class Redirect extends ContentEntityBase {
    */
   public static function generateHash($source_path, array $source_query, $language) {
     $hash = array(
-      'source' => strtolower($source_path),
+      'source' => Unicode::strtolower($source_path),
       'language' => $language,
     );
 

--- a/src/Tests/RedirectAPITest.php
+++ b/src/Tests/RedirectAPITest.php
@@ -123,6 +123,27 @@ class RedirectAPITest extends KernelTestBase {
     else {
       $this->fail('Failed to find a redirect by source path with query string.');
     }
+
+    // Hashes should be case-insensitive since the source paths are.
+    /** @var \Drupal\redirect\Entity\Redirect $redirect */
+    $redirect = $this->controller->create();
+    $redirect->setSource('Case-Sensitive-Path');
+    $redirect->save();
+    $found = $repository->findBySourcePath('case-sensitive-path');
+    if (!empty($found)) {
+      $found = reset($found);
+      $this->assertEqual($found->getSourceUrl(), '/Case-Sensitive-Path');
+    }
+    else {
+      $this->fail('findBySourcePath is case sensitive');
+    }
+    $found = $repository->findMatchingRedirect('case-sensitive-path');
+    if (!empty($found)) {
+      $this->assertEqual($found->getSourceUrl(), '/Case-Sensitive-Path');
+    }
+    else {
+      $this->fail('findMatchingRedirect is case sensitive.');
+    }
   }
 
   /**


### PR DESCRIPTION
Adding a redirect from `FoO` will result in a 404 when visiting `foo`. However, if one then attempts to add `foo` as a new redirect, they are unable to do so since the `RedirectRepository::findBySourcePath()` is case-insensitive.

This makes the hashes case-insensitive to match that behavior.
