### PR TITLE
Wrong configuration link

### DIFF
--- a/redirect.info.yml
+++ b/redirect.info.yml
@@ -2,7 +2,7 @@ name: Redirect
 type: module
 description: Allows users to redirect from old URLs to new URLs.
 core: 8.x
-configure: redirect.admin_settings
+configure: redirect.settings
 
 dependencies:
  - link


### PR DESCRIPTION
When I enable this module the module did not have a configuration link in the modules pages. I went to the module and I notice that the configuration button was wrong. So I add the correct link.
