### PR TITLE
Test on supported versions of PHP.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,13 @@ cache:
   apt: true
 
 php:
-  - 5.4
   - 5.5
+  - 5.6
+  - 7.0
+
+matrix:
+  allow_failures:
+    - php: 7.0
 
 env:
   - PATH=$PATH:/home/travis/.composer/vendor/bin


### PR DESCRIPTION
PHP 5.4 is failing. This also adds 5.6, and 7.0 with allowed failures.
