### PR TITLE
The `type` field isn't actually a bundle.

### DIFF
--- a/src/Entity/Redirect.php
+++ b/src/Entity/Redirect.php
@@ -39,7 +39,6 @@ use Drupal\link\LinkItemInterface;
  *     "id" = "rid",
  *     "label" = "source",
  *     "uuid" = "uuid",
- *     "bundle" = "type",
  *     "langcode" = "language",
  *   },
  *   links = {


### PR DESCRIPTION
Unless I'm misunderstanding this, I don't think the `type` field is being used for bundles. This is causing problems when attempting to automatically update entity bundle field schemas.
