### PR TITLE
Improve hash upgrade path

### DIFF
--- a/redirect.install
+++ b/redirect.install
@@ -5,6 +5,7 @@
  */
 
 use Drupal\redirect\Entity\Redirect;
+use Drupal\Core\Database\Database;
 
 /**
  * Rehash redirects to account for case insensitivity.
@@ -41,4 +42,32 @@ function redirect_update_8100(&$sandbox) {
   }
   // Reset caches.
   $sandbox['#finished'] = empty($sandbox['max']) ? 1 : ($sandbox['progress'] / $sandbox['max']);
+}
+
+
+/**
+ * Update the {redirect} table.
+ */
+function redirect_update_8101() {
+  // Get the current schema, change the length.
+  $key_value_store_schema = \Drupal::keyValue('entity.storage_schema.sql');
+  $schema = $key_value_store_schema->get('redirect.field_schema_data.hash');
+  $schema['redirect']['fields']['hash']['length'] = 64;
+
+  // Set the max_length of the hash column to 64 characters.
+  Database::getConnection()
+    ->schema()
+    ->changeField('redirect', 'hash', 'hash', $schema['redirect']['fields']['hash']);
+
+  // Update the last installed field definition and field schema.
+  /** @var \Drupal\Core\KeyValueStore\KeyValueStoreInterface $key_value_store */
+  \Drupal::entityManager()->clearCachedFieldDefinitions();
+  $key_value_store_definition = \Drupal::keyValue('entity.definitions.installed');
+  $storage_definitions = $key_value_store_definition->get('redirect.field_storage_definitions');
+  $storage_definitions['hash'] = $storage_definition = \Drupal::entityManager()
+    ->getFieldStorageDefinitions('redirect')['hash'];
+  $key_value_store_definition->set('redirect.field_storage_definitions', $storage_definitions);
+
+  // Update the stored schema.
+  $key_value_store_schema->set('redirect.field_schema_data.hash', $schema);
 }

--- a/redirect.install
+++ b/redirect.install
@@ -9,7 +9,7 @@ use Drupal\redirect\Entity\Redirect;
 /**
  * Rehash redirects to account for case insensitivity.
  */
-function redirect_update_8100 (&$sandbox) {
+function redirect_update_8100(&$sandbox) {
   // Loop through 100 redirects at a time.
   if (!isset($sandbox['progress'])) {
     $sandbox['progress'] = 0;
@@ -18,31 +18,26 @@ function redirect_update_8100 (&$sandbox) {
     $sandbox['max'] = db_query('SELECT COUNT(1) FROM {redirect}')->fetchField();
   }
 
-  $redirects = db_select('redirect', 'r')
-    ->fields('r', ['rid'])
+  $result = db_select('redirect', 'r')
+    ->fields('r', ['rid', 'redirect_source__path', 'redirect_source__query', 'language', 'hash'])
     ->condition('rid', $sandbox['current_rid'], '>')
     ->range(0, 100)
     ->orderBy('rid', 'ASC')
     ->execute()
     ->fetchCol();
 
-  /** @var \Drupal\redirect\RedirectRepository $repository */
-  $repository = \Drupal::service('redirect.repository');
-  $redirects = $repository->loadMultiple($redirects);
-  foreach ($redirects as $redirect) {
-    $source = $redirect->get('redirect_source')->get(0)->getValue();
-    $language = $redirect->get('language')->get(0)->getValue()['value'];
-    $query = $source['query'] ?: [];
-    $new_hash = Redirect::generateHash($source['path'], $query, $language);
-    if ($redirect->getHash() != $new_hash) {
+  foreach ($result as $row) {
+    $query = !empty($row->redirect_source__query) ? unserialize($row->redirect_source__query): [];
+    $new_hash = Redirect::generateHash($row->redirect_source__path, $query, $row->language);
+    if ($row->hash != $new_hash) {
       // Do a direct query to speed things up.
       db_update('redirect')
         ->fields(['hash' => $new_hash])
-        ->condition('rid', $redirect->id())
+        ->condition('rid', $row->rid)
         ->execute();
     }
     $sandbox['progress']++;
-    $sandbox['current_rid'] = $redirect->id();
+    $sandbox['current_rid'] = $row->rid;
   }
   // Reset caches.
   $sandbox['#finished'] = empty($sandbox['max']) ? 1 : ($sandbox['progress'] / $sandbox['max']);


### PR DESCRIPTION
Changes the hash upgrade path to use database queries instead of loading entities. Loading entities conflicts with the new created field.

Also adds an update function for updating the length of the has field.
