### PR TITLE
Fix redirect form ajax callback

### DIFF
--- a/redirect.module
+++ b/redirect.module
@@ -398,5 +398,5 @@ function redirect_redirect_operations() {
  * Ajax callback for the redirect link widget.
  */
 function redirect_source_link_get_status_messages(array $form, FormStateInterface $form_state) {
-  return $form['redirect_source']['widget'][0]['status_box'];
+  return !empty($form['redirect_source']['widget'][0]['status_box'][0]['#markup']) ? $form['redirect_source']['widget'][0]['status_box'] : [];
 }


### PR DESCRIPTION
- The ajax callback was making the form unusable by always setting focus
  back on the `path` input area.

This is a temporary fix for #67 that makes the form usable again. I'm not exactly sure what the intention of the ajax callback is at the moment.
