### PR TITLE
Prevent changes to the request during onKernelRequestCheckRedirect

### DIFF
--- a/src/EventSubscriber/RedirectRequestSubscriber.php
+++ b/src/EventSubscriber/RedirectRequestSubscriber.php
@@ -119,7 +119,12 @@ class RedirectRequestSubscriber implements EventSubscriberInterface {
    *   The event to process.
    */
   public function onKernelRequestCheckRedirect(GetResponseEvent $event) {
-    // Get a clone of the request as it might be altered during inbound processing.
+    // Get a clone of the request. During inbound processing the request
+    // can be altered. Allowing this here can lead to unexpected behavior.
+    // For example the path_processor.files inbound processor provided by
+    // the system module alters both the path and the request; only the
+    // changes to the request will be propagated, while the change to the
+    // path will be lost.
     $request = clone $event->getRequest();
 
     if (!$this->checker->canRedirect($request)) {

--- a/src/EventSubscriber/RedirectRequestSubscriber.php
+++ b/src/EventSubscriber/RedirectRequestSubscriber.php
@@ -119,7 +119,8 @@ class RedirectRequestSubscriber implements EventSubscriberInterface {
    *   The event to process.
    */
   public function onKernelRequestCheckRedirect(GetResponseEvent $event) {
-    $request = $event->getRequest();
+    // Get a clone of the request as it might be altered during inbound processing.
+    $request = clone $event->getRequest();
 
     if (!$this->checker->canRedirect($request)) {
       return;

--- a/tests/src/Unit/RedirectRequestSubscriberTest.php
+++ b/tests/src/Unit/RedirectRequestSubscriberTest.php
@@ -11,9 +11,12 @@ use Drupal\Core\Language\Language;
 use Drupal\redirect\EventSubscriber\RedirectRequestSubscriber;
 use Drupal\Tests\UnitTestCase;
 use PHPUnit_Framework_MockObject_MockObject;
+use Symfony\Component\HttpFoundation\FileBag;
+use Symfony\Component\HttpFoundation\HeaderBag;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ServerBag;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\PostResponseEvent;
 

--- a/tests/src/Unit/RedirectRequestSubscriberTest.php
+++ b/tests/src/Unit/RedirectRequestSubscriberTest.php
@@ -273,7 +273,12 @@ class RedirectRequestSubscriberTest extends UnitTestCase {
       ->with('GET')
       ->will($this->returnValue(TRUE));
 
+    $request->query = new ParameterBag();
     $request->attributes = new ParameterBag();
+    $request->cookies = new ParameterBag();
+    $request->files = new FileBag();
+    $request->server = new ServerBag();
+    $request->headers = new HeaderBag();
 
     $http_kernel = $this->getMockBuilder('\Symfony\Component\HttpKernel\HttpKernelInterface')
       ->getMock();


### PR DESCRIPTION
The redirect module prevents the system.private_file_download route from working. This route is accompanied by a inbound processor "path_processor.files" that alters the path and the request, moving everything after /system/files to a query argument. The redirect module calls the inbound processes very early and allows the request object to be altered while changes to the path are not propagated. This results in the router.route_provider no longer finding the system.private_file_download route.
