### PR TITLE
[#80] Fix AJAX call and remove focus() on redirect form

### DIFF
--- a/redirect.module
+++ b/redirect.module
@@ -398,5 +398,5 @@ function redirect_redirect_operations() {
  * Ajax callback for the redirect link widget.
  */
 function redirect_source_link_get_status_messages(array $form, FormStateInterface $form_state) {
-  return !empty($form['redirect_source']['widget'][0]['status_box'][0]['#markup']) ? $form['redirect_source']['widget'][0]['status_box'] : [];
+  return $form['redirect_source']['widget'][0]['status_box'];
 }

--- a/src/Plugin/Field/FieldWidget/RedirectSourceWidget.php
+++ b/src/Plugin/Field/FieldWidget/RedirectSourceWidget.php
@@ -51,6 +51,7 @@ class RedirectSourceWidget extends WidgetBase {
       '#maxlength' => 2048,
       '#required' => $element['#required'],
       '#field_prefix' => \Drupal::url('<front>', array(), array('absolute' => TRUE)),
+      '#attributes' => array('data-disable-refocus' => 'true'),
     );
 
     // If creating new URL add checks.


### PR DESCRIPTION
Fixes https://github.com/md-systems/redirect/issues/79.

The AJAX response was causing a bunch of PHP warnings starting with this one:

```
Notice: Undefined index: #attached in Drupal\Core\Render\MainContent\AjaxRenderer->renderResponse() (line 68 of /var/www/drupal8/core/lib/Drupal/Core/Render/MainContent/AjaxRenderer.php).
```

This is because we were returning an array, which was interpreted by core as an AjaxResponse object. Once this was fixed, there was a weird behavior with ajax.js focusing on the field every time the ajax request would finish. The full details of this issue can be found at https://www.drupal.org/node/2627788. I included a fix for this too.
