### PR TITLE
Fix path setup for urls

### DIFF
--- a/src/Plugin/Field/FieldType/RedirectSourceItem.php
+++ b/src/Plugin/Field/FieldType/RedirectSourceItem.php
@@ -111,7 +111,9 @@ class RedirectSourceItem extends FieldItemBase {
    * {@inheritdoc}
    */
   public function getUrl() {
-    return Url::fromUri('base:' . $this->path, ['query' => $this->query]);
+    // Core expects urls to start with / but the hash needs to be generated
+    // without the / as the Request path doesn't have this.
+    return Url::fromUri('base:/' . $this->path, ['query' => $this->query]);
   }
 
 }


### PR DESCRIPTION
It's unclear if paths should be entered with or without forward slash, but it seems both doesn't work.

The interface suggests that urls shouldn't be entered with forward slash, since it says `http://example.com/ [                   ]`. If you enter urls without forward slash RedirectSourceItem::getUrl gives fatal error. If you enter urls with forward slash it doesn't match the actual URLs and instead a 404 is displayed instead of the redirect happening.

This patch fixes the fatal error, which makes it possible to enter correct urls and the redirect happen as expected.
