### PR TITLE
Don't allow redirects source to start with /

### DIFF
--- a/src/Form/RedirectForm.php
+++ b/src/Form/RedirectForm.php
@@ -98,6 +98,9 @@ class RedirectForm extends ContentEntityForm {
     if (strpos($source['path'], '#') !== FALSE) {
       $form_state->setErrorByName('redirect_source', t('The anchor fragments are not allowed.'));
     }
+    if (strpos($source['path'], '/') === 0) {
+      $form_state->setErrorByName('redirect_source', t('The url to redirect from should not start with a forward slash (/).'));
+    }
 
     try {
       $source_url = Url::fromUri('internal:/' . $source['path']);

--- a/src/Tests/RedirectUITest.php
+++ b/src/Tests/RedirectUITest.php
@@ -166,6 +166,13 @@ class RedirectUITest extends WebTestBase {
     ), t('Save'));
     $this->assertRaw(t('The anchor fragments are not allowed.'));
 
+    // Adding path that starts with /
+    $this->drupalPostForm('admin/config/search/redirect/add', array(
+      'redirect_source[0][path]' => '/page-to-redirect',
+      'redirect_redirect[0][uri]' => '/node',
+    ), t('Save'));
+    $this->assertRaw(t('The url to redirect from should not start with a forward slash (/).'));
+
     // Test filters.
     // Add a new redirect.
     $this->drupalPostForm('admin/config/search/redirect/add', array(


### PR DESCRIPTION
Improve the UX by catching the most obvious error - creating redirects starting with / which is how you do it almost all other places in Drupal 8.
