### PR TITLE
Point label entity key to real field.

### DIFF
--- a/src/Entity/Redirect.php
+++ b/src/Entity/Redirect.php
@@ -38,7 +38,7 @@ use Drupal\link\LinkItemInterface;
  *   admin_permission = "administer redirects",
  *   entity_keys = {
  *     "id" = "rid",
- *     "label" = "source",
+ *     "label" = "redirect_source",
  *     "uuid" = "uuid",
  *     "bundle" = "type",
  *     "langcode" = "language",


### PR DESCRIPTION
This caused a fatal error:

`Fatal error: Call to a member function getFieldStorageDefinition() on null in /var/www/site/web/core/lib/Drupal/Core/Entity/ContentEntityBase.php on line 1100`

Reproducible by:

```
$redirect = Redirect::load(1);
$label = $redirect->label();
```
