### PR TITLE
Fix redirect_path_update()

### DIFF
--- a/redirect.module
+++ b/redirect.module
@@ -81,7 +81,7 @@ function redirect_path_update(array $path) {
   // Delete all redirects having the same source as this alias.
   redirect_delete_by_path($path['alias'], $path['langcode'], FALSE);
   if ($original_path['alias'] != $path['alias']) {
-    if (!redirect_repository()->findMatchingRedirect($original_path['alias'], array(), $original_path['langcode'])) {
+    if (!redirect_repository()->findMatchingRedirect(ltrim($original_path['alias'], '/'), array(), $original_path['langcode'])) {
       $redirect = Redirect::create();
       $redirect->setSource($original_path['alias']);
       $redirect->setRedirect($path['source']);


### PR DESCRIPTION
Redirect module crashes in `redirect_path_update()` with `Integrity constraint violation: 1062 Duplicate entry '5WDyk0tILigTJ0G3fwSptWecGOuwGZuJJy_Nsmg3Ebk' for key 'hash'` if a redirect exists already.

`findMatchingRedirect()` never finds duplicate because path alias always contains `/`.
